### PR TITLE
Prevent backslashes from being stripped on post insertion

### DIFF
--- a/src/WXRImporter.php
+++ b/src/WXRImporter.php
@@ -851,6 +851,8 @@ class WXRImporter extends \WP_Importer {
 		}
 
 		$postdata = apply_filters( 'wp_import_post_data_processed', $postdata, $data );
+		
+		$postdata = wp_slash( $postdata );
 
 		if ( 'attachment' === $postdata['post_type'] ) {
 			if ( ! $this->options['fetch_attachments'] ) {


### PR DESCRIPTION
In content created with Gutenberg editor, some characters (used in block attribute) are encoded into unicode character codes that start with a backslash, e.g.
```
<!-- wp:plugin/custom-block {"data":"Some text and \u003ca href=\u0022https://example.com/\u0022\u003esome-link\u003c/a\u003e."} /-->
```
Before inserting into database, `wp_insert_post()` function runs the post object through `wp_unslash()` function which strips all backslashes. This breaks unicode character codes (and content). To mitigate that, we should run the post object through `wp_slash()` functions before passing it to `wp_insert_post()`. The original WordPress Importer does this.